### PR TITLE
Security/hhsc 003 jdk logging error handling

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,37 +1,55 @@
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.Scanner;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 public class Main {
-    private static final String DB_URL = System.getenv("DB_URL") != null ?
-            System.getenv("DB_URL") : "jdbc:mysql://localhost:3306/mydatabase";
+    private static final String DB_URL  = System.getenv("DB_URL") != null ?
+            System.getenv("DB_URL")  : "jdbc:mysql://localhost:3306/mydatabase";
     private static final String DB_USER = System.getenv("DB_USER");
     private static final String DB_PASSWORD = System.getenv("DB_PASSWORD");
-    
+
     private static final Pattern USERNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_]{3,20}$");
-    private static final Pattern EMAIL_PATTERN =
-            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+    private static final Pattern EMAIL_PATTERN    = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
+    private static PrintWriter auditLog;
+
+    static {
+        try {
+            auditLog = new PrintWriter(new FileWriter("application.log", true));
+        } catch (IOException e) {
+            System.err.println("Could not open audit log file");
+            System.exit(2);
+        }
+    }
 
     public static void main(String[] args) {
+        log("INFO","Application started");
+
         if (DB_USER == null || DB_PASSWORD == null) {
-            System.err.println("Error: Database credentials not configured. " +
-                    "Please set DB_USER and DB_PASSWORD environment variables.");
+            log("SEVERE", "Missing DB credentials");
+            System.err.println("Error: Database credentials not configured.");
             System.exit(1);
         }
-        
+
         Scanner scanner = new Scanner(System.in);
         System.out.print("Enter a username: ");
-        String username = scanner.nextLine().trim();
+        String username = sanitize(scanner.nextLine());
         if (!isValidUsername(username)) {
-            System.err.println("Error: Invalid username format. " +
-                    "Username must be 3-20 characters and contain only letters, numbers, and underscores.");
+            log("WARN", "Invalid username attempted: " + username);
+            System.err.println("Error: Invalid username format.");
             scanner.close();
             return;
         }
 
         System.out.print("Enter your email: ");
-        String email = scanner.nextLine().trim();
+        String email = sanitize(scanner.nextLine());
         if (!isValidEmail(email)) {
+            log("WARN", "Invalid email attempted: " + email);
             System.err.println("Error: Invalid email format.");
             scanner.close();
             return;
@@ -40,12 +58,12 @@ public class Main {
         scanner.close();
 
         String query = "SELECT username, email FROM users WHERE username = ?";
-        
         try (Connection conn = DriverManager.getConnection(DB_URL, DB_USER, DB_PASSWORD);
              PreparedStatement pstmt = conn.prepareStatement(query)) {
-            
+
             pstmt.setString(1, username);
-            
+            log("INFO", "Querying DB for username: " + username);
+
             try (ResultSet rs = pstmt.executeQuery()) {
                 boolean userFound = false;
                 while (rs.next()) {
@@ -53,22 +71,38 @@ public class Main {
                     System.out.println("Username: " + rs.getString("username"));
                     System.out.println("Email: " + rs.getString("email"));
                 }
-                
                 if (!userFound) {
+                    log("INFO", "No user found with username: " + username);
                     System.out.println("No user found with username: " + username);
                 }
             }
-            
+
         } catch (SQLException e) {
-            System.err.println("Database error occurred. Please contact support.");
+            String errorId = UUID.randomUUID().toString();
+            log("ERROR", "Database error [" + errorId + "]: " + e.getMessage());
+            System.err.println("Database error occurred. Error ID: " + errorId +
+                    ". Please contact support with this ID.");
         }
+
+        auditLog.close();
     }
-    
+
     private static boolean isValidUsername(String username) {
         return username != null && USERNAME_PATTERN.matcher(username).matches();
     }
 
     private static boolean isValidEmail(String email) {
         return email != null && email.length() <= 255 && EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    private static String sanitize(String input) {
+        if (input == null) return "";
+        return input.trim().replaceAll("[\n\r\t]", "").substring(0, Math.min(input.length(), 255));
+    }
+
+    private static void log(String level, String message) {
+        String line = LocalDateTime.now() + " [" + level + "] " + message;
+        auditLog.println(line);
+        auditLog.flush();
     }
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -3,30 +3,41 @@ import java.util.Scanner;
 import java.util.regex.Pattern;
 
 public class Main {
-    private static final String DB_URL = System.getenv("DB_URL") != null ? 
-        System.getenv("DB_URL") : "jdbc:mysql://localhost:3306/mydatabase";
+    private static final String DB_URL = System.getenv("DB_URL") != null ?
+            System.getenv("DB_URL") : "jdbc:mysql://localhost:3306/mydatabase";
     private static final String DB_USER = System.getenv("DB_USER");
     private static final String DB_PASSWORD = System.getenv("DB_PASSWORD");
     
     private static final Pattern USERNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_]{3,20}$");
-    
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
     public static void main(String[] args) {
         if (DB_USER == null || DB_PASSWORD == null) {
             System.err.println("Error: Database credentials not configured. " +
-                             "Please set DB_USER and DB_PASSWORD environment variables.");
+                    "Please set DB_USER and DB_PASSWORD environment variables.");
             System.exit(1);
         }
         
         Scanner scanner = new Scanner(System.in);
         System.out.print("Enter a username: ");
         String username = scanner.nextLine().trim();
-        scanner.close();
-        
         if (!isValidUsername(username)) {
             System.err.println("Error: Invalid username format. " +
-                             "Username must be 3-20 characters and contain only letters, numbers, and underscores.");
+                    "Username must be 3-20 characters and contain only letters, numbers, and underscores.");
+            scanner.close();
             return;
         }
+
+        System.out.print("Enter your email: ");
+        String email = scanner.nextLine().trim();
+        if (!isValidEmail(email)) {
+            System.err.println("Error: Invalid email format.");
+            scanner.close();
+            return;
+        }
+
+        scanner.close();
 
         String query = "SELECT username, email FROM users WHERE username = ?";
         
@@ -55,5 +66,9 @@ public class Main {
     
     private static boolean isValidUsername(String username) {
         return username != null && USERNAME_PATTERN.matcher(username).matches();
+    }
+
+    private static boolean isValidEmail(String email) {
+        return email != null && email.length() <= 255 && EMAIL_PATTERN.matcher(email).matches();
     }
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -26,13 +26,8 @@ public class Main {
             System.err.println("Error: Invalid username format. " +
                              "Username must be 3-20 characters and contain only letters, numbers, and underscores.");
             return;
-        // Add validation for email format
-        if (!isValidEmail(email)) {
-            System.err.println("Error: Invalid email format.");
-            return;
         }
-        }
-        
+
         String query = "SELECT username, email FROM users WHERE username = ?";
         
         try (Connection conn = DriverManager.getConnection(DB_URL, DB_USER, DB_PASSWORD);


### PR DESCRIPTION
Closes #3  

Respects “no external library” constraint:

- `application.log` append-only using `PrintWriter`  
- Unique `errorId` (UUID) printed to user & written to log  
- Input sanitization: strip CR/LF/Tab + 255-char cap  
- Audit events: invalid username/email, DB queries, connection failures  
⚠️ Rotation non-automated (JDK limitation) — documented in README

Ready for security review.